### PR TITLE
Resolve docker_cmd argumnet error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ checks:
 ```yaml
 repos:
   - repo: https://github.com/jtyr/pre-commit-hooks
-    rev: v1.3.2
+    rev: v1.3.3
     hooks:
       - id: docker-image
         name: Run /tools/validate.sh in container
@@ -45,7 +45,7 @@ Helm chart version, this hook helps to prevent the overwrite.
 ```yaml
 repos:
   - repo: https://github.com/jtyr/pre-commit-hooks
-    rev: v1.3.2
+    rev: v1.3.3
     hooks:
       - id: check-helm-version
 ```
@@ -57,7 +57,7 @@ the `--branch` argument:
 ```yaml
 repos:
   - repo: https://github.com/jtyr/pre-commit-hooks
-    rev: v1.3.2
+    rev: v1.3.3
     hooks:
       - id: check-helm-version
         args:
@@ -71,7 +71,7 @@ argument:
 ```yaml
 repos:
   - repo: https://github.com/jtyr/pre-commit-hooks
-    rev: v1.3.2
+    rev: v1.3.3
     hooks:
       - id: check-helm-version
         args:
@@ -85,7 +85,7 @@ the `--autofix` argument:
 ```yaml
 repos:
   - repo: https://github.com/jtyr/pre-commit-hooks
-    rev: v1.3.2
+    rev: v1.3.3
     hooks:
       - id: check-helm-version
         args:
@@ -99,7 +99,7 @@ with the `--autofix-portion` argument:
 ```yaml
 repos:
   - repo: https://github.com/jtyr/pre-commit-hooks
-    rev: v1.3.2
+    rev: v1.3.3
     hooks:
       - id: check-helm-version
         args:

--- a/hooks/docker_image.py
+++ b/hooks/docker_image.py
@@ -153,7 +153,7 @@ def main() -> None:
     DOCKER._get_container_id = _get_container_id
 
     # Get docker command enriched by the hook args
-    cmd = DOCKER.docker_cmd() + tuple(SYS_ARGV[1:])
+    cmd = DOCKER.docker_cmd(color=False) + tuple(SYS_ARGV[1:])
 
     # Run the command
     try:

--- a/tests/docker_image.py
+++ b/tests/docker_image.py
@@ -473,7 +473,7 @@ class TestDockerImage(MyTestCase):
 
         import hooks.docker_image as di
 
-        def docker_cmd_test():
+        def docker_cmd_test(color=False):
             return self.___cmd
 
         # Mock function


### PR DESCRIPTION
This PR addresses the argument error for the `docker_cmd` command introduced in the [pre-commit version v3.7.0](https://github.com/pre-commit/pre-commit/commit/e58009684cfc4842028e99d34837e2722af39b93) by addition of required `color` parameter to the function in scope.

Error sample:
```
$ pre-commit run docker-image --all-files
Validate app directory and files.........................................Failed
- hook id: docker-image
- exit code: 1

Traceback (most recent call last):
  File "/Users/vladimir/.cache/pre-commit/repox_re6swk/py_env-python3.12/bin/docker-image", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/vladimir/.cache/pre-commit/repox_re6swk/py_env-python3.12/lib/python3.12/site-packages/hooks/docker_image.py", line 156, in main
    cmd = DOCKER.docker_cmd() + tuple(SYS_ARGV[1:])
          ^^^^^^^^^^^^^^^^^^^
TypeError: docker_cmd() missing 1 required keyword-only argument: 'color'
```